### PR TITLE
Fix logStart

### DIFF
--- a/bin/resque-scheduler.php
+++ b/bin/resque-scheduler.php
@@ -76,6 +76,6 @@ function logStart($logger, $message, $logLevel)
         $message['data']['worker'] = $host . ':' . $pid;
         $message['data']['queues'] = explode(',', $queues);
 
-        $logger->getInstance()->addInfo($message['message'], $message['data']);
+        $logger->getInstance()->info($message['message'], $message['data']);
     }
 }


### PR DESCRIPTION
This PR fixes the resque scheduler, that wouldn't start, because it was trying to call a non existent (old?) method on the Monolog/Logger class.